### PR TITLE
fixes default context for an org

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
            uses: ambilykk/actions-custom-oidc-claim@main
            with:
               GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}  
-              claim-keys: repo,context
+              claim-keys: repo, context
 ```
 
 2: Revert back to the default OIDC subject claim for repository 
@@ -44,7 +44,7 @@ jobs:
            uses: ambilykk/actions-custom-oidc-claim@main
            with:
               GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}  
-              claim-keys: repo,context, repository_owner
+              claim-keys: repo, context, repository_owner
               org-repo: org
 ```
 
@@ -54,7 +54,7 @@ jobs:
 |--------------------------------|-----------|---------------|-------------------------------------------------------|
 | GITHUB_TOKEN                 | Yes |  | PAT Token for access    |
 | org-repo                      | No | repo | Specify the scope of the subject claim - repo or org                  |
-| claim-keys                     | No | repo | Comma separated list of claim keys      |
+| claim-keys                     | No | repo, context | Comma separated list of claim keys      |
 | use-default                    | No | false | Use the default sub claim format |
 
 

--- a/action.yml
+++ b/action.yml
@@ -6,14 +6,18 @@ branding:
 inputs:
   GITHUB_TOKEN:
     description: 'GitHub token'
-    required: true 
+    required: true
   org-repo:
-    description: 'OIDC claim for organization or repository'    
-    default: 'repo'
-  claim-keys: 
-    description: 'Comma separated list of claim keys'    
-    default: 'repo'
-  use-default: 
+    type: choice
+    description: 'OIDC claim for organization or repository'
+    options:
+      - org
+      - repo
+  claim-keys:
+    description: 'Comma separated list of claim keys'
+    default: 'repo, context'
+  use-default:
+    type: boolean
     description: 'Use the default OIDC claim subject'
     default: false
 

--- a/app/index.js
+++ b/app/index.js
@@ -21,31 +21,25 @@ if (org_repo == 'org') {
 async function run() {
     try {
         let req_body = {};
-        // revert back to default subject identifier
-        if (use_default == 'true') {
+
+        // set the claim keys for organization 
+        if (org_repo == 'org') {
             req_body = {
-                "use_default": true
+                org: github.context.repo.owner,
+                url,
+                method: 'PUT',
+                include_claim_keys: use_default? ['repo', 'context'] : claim_keys.split(',').map(item => item.trim())
             }
-        } else {
-            // set the claim keys for organization 
-            if (org_repo == 'org') {
-                req_body = {
-                    org: github.context.repo.owner,
-                    url,
-                    method: 'PUT',
-                    use_default: false,
-                    include_claim_keys: claim_keys.split(',')
-                }
-            } else {
-                // set the claim keys for repository 
-                req_body = {
-                    owner: github.context.repo.owner,
-                    repo: github.context.repo.repo,
-                    url,
-                    method: 'PUT',
-                    use_default: false,
-                    include_claim_keys: claim_keys.split(',')
-                }
+        }
+        else if (org_repo == 'repo') {
+            // set the claim keys for repository 
+            req_body = {
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                url,
+                method: 'PUT',
+                use_default,
+                include_claim_keys: use_default? [] : claim_keys.split(',').map(item => item.trim())
             }
         }
         


### PR DESCRIPTION
### Description
`use_default` isn't a valid request payload on customizing subject claim for an organization see [here](https://docs.github.com/en/enterprise-cloud@latest/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-an-organization).

Validation issues:

- require to trim claim keys before passing it to request payload.
- use_default should be of type boolean in action.yml

Additionally, if `use_default` is set to true at org/repo level,  request payload isnt complete to be able to invoke an api request.